### PR TITLE
Remove console.log of strategy configuration

### DIFF
--- a/lib/passport-bitbucket/strategy.js
+++ b/lib/passport-bitbucket/strategy.js
@@ -59,7 +59,6 @@ function Strategy(options, verify) {
   this.name = 'bitbucket';
   this._userProfileURL = options.userProfileURL || 'https://api.bitbucket.org/2.0/user';
   this._oauth2.useAuthorizationHeaderforGET(true);
-  console.log(this);
 }
 
 /**


### PR DESCRIPTION
This output may in some situations be desirable in general writing security relevant information to console.log is not desirable