### PR TITLE
passport-oauth2@1.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-bitbucket",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth2": "^1.1.2"
+    "passport-oauth2": "1.3.x"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
update to the latest version of `passport-oauth2` (there are no breaking changes)
