### PR TITLE
Replace username with nickname, remove profileUrl, add accountId

### DIFF
--- a/lib/passport-bitbucket/profile.js
+++ b/lib/passport-bitbucket/profile.js
@@ -12,9 +12,9 @@ exports.parse = function(json) {
   
   var profile = {};
   profile.id = json.uuid;
+  profile.accountId = json.account_id
   profile.displayName = json.display_name;
-  profile.username = json.username;
-  profile.profileUrl = json.links.html.href;
+  profile.nickname = json.nickname;
 
   return profile;
 };

--- a/lib/passport-bitbucket/strategy.js
+++ b/lib/passport-bitbucket/strategy.js
@@ -74,9 +74,9 @@ util.inherits(Strategy, OAuth2Strategy);
  *
  *   - `provider`         always set to `bitbucket`
  *   - `id`               the user's Bitbucket uuid
- *   - `username`         the user's Bitbucket username
+ *   - `accountId`        the user's Atlassian account id
+ *   - `nickname`         the user's Bitbucket nickname
  *   - `displayName`      the user's full name
- *   - `profileUrl`       the URL of the profile for the user on Bitbucket
  *
  * @param {String} accessToken
  * @param {Function} done

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -92,11 +92,11 @@ vows.describe('BitbucketStrategy').addBatch({
               } \
             ], \
             "user": { \
-                "username": "jaredhanson", \
+                "nickname": "jaredhanson", \
                 "first_name": "Jared", \
                 "last_name": "Hanson", \
                 "avatar": "https://secure.gravatar.com/avatar/6c43616eef331e8ad08c7f90a51069a5?d=identicon&s=32", \
-                "resource_uri": "/1.0/users/jaredhanson" \
+                "resource_uri": "/2.0/users/jaredhanson" \
             } \
         }';
         
@@ -123,7 +123,7 @@ vows.describe('BitbucketStrategy').addBatch({
       },
       'should load profile' : function(err, profile) {
         assert.equal(profile.provider, 'bitbucket');
-        assert.equal(profile.username, 'jaredhanson');
+        assert.equal(profile.nickname, 'jaredhanson');
         assert.equal(profile.displayName, 'Jared Hanson');
         assert.equal(profile.name.familyName, 'Hanson');
         assert.equal(profile.name.givenName, 'Jared');


### PR DESCRIPTION
Due to GDPR changes `username` and user profile URL are deprecated. Now instead of `username` we can use `nickname`.

Close #9 